### PR TITLE
Just dock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.11-slim
 
-# 1. Install system dependencies (needed for building some Python deps)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        gcc \
@@ -10,20 +9,15 @@ RUN apt-get update \
        build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Install Poetry
 RUN pip install --no-cache-dir poetry
 
-# 3. Set workdir
 WORKDIR /app
 
-# 4. Copy dependency files first (for Docker cache efficiency)
 COPY pyproject.toml poetry.lock* /app/
 
-# 5. Install project dependencies (no dev in production)
-RUN poetry install --no-interaction --no-ansi --without dev
+# ✅ Removed "--without dev" since you don’t have a dev group
+RUN poetry install --no-interaction --no-ansi
 
-# 6. Copy project source
 COPY . /app
 
-# 7. Run Nancy bot
 CMD ["poetry", "run", "nancy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY pyproject.toml poetry.lock* /app/
 RUN pip install "poetry==2.1.4"
 
 # Export Poetry deps → requirements.txt → pip install
+RUN poetry self add poetry-plugin-export
 RUN poetry export -f requirements.txt --without-hashes -o requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,38 @@
-FROM python:3.11-slim
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       gcc \
-       libffi-dev \
-       libssl-dev \
-       curl \
-       build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir poetry
+FROM python:3.12-alpine AS builder
 
 WORKDIR /app
 
-COPY pyproject.toml poetry.lock* /app/
+# Install build deps for wheels (aiohttp/yarl/etc.)
+RUN apk add --no-cache build-base libffi-dev openssl-dev
 
-# ✅ Removed "--without dev" since you don’t have a dev group
-RUN poetry install
+# Copy project metadata
+ADD pyproject.toml poetry.lock /app/
 
-COPY . /app
+# Install Poetry and deps into in-project venv
+RUN pip install --no-cache-dir "poetry==2.1.4"
+RUN poetry config virtualenvs.in-project true
+RUN poetry install --no-ansi --no-interaction --only main
 
-CMD ["poetry", "run", "nancy"]
+# Final image
+FROM python:3.12-alpine
+WORKDIR /app
+
+# Runtime libs
+RUN apk add --no-cache libffi openssl
+
+# Bring venv and metadata from builder, then project sources
+COPY --from=builder /app /app
+ADD . /app
+
+# Create non-root user and set permissions
+RUN addgroup -g 1000 app \
+ && adduser -h /app -u 1000 -G app -D app \
+ && chown -R app:app /app
+USER app
+
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+# Run the aiohttp bot (no gunicorn; runs on port 8000)
+CMD ["/app/.venv/bin/python", "-m", "nancyai.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
 ENV PYTHONPATH=/app/src
+# Expose bot server port
+EXPOSE 8000
+
+# Start bot
 CMD ["python", "-m", "nancyai.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy app source
 COPY . /app
 
+ENV PYTHONPATH=/app/src
 CMD ["python", "-m", "nancyai.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
-# --- Base image ---
 FROM python:3.11-slim
 
-# --- Install dependencies ---
+# 1. Install system dependencies (needed for building some Python deps)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       gcc \
+       libffi-dev \
+       libssl-dev \
+       curl \
+       build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Install Poetry
 RUN pip install --no-cache-dir poetry
 
-# --- Set workdir ---
+# 3. Set workdir
 WORKDIR /app
 
-# --- Copy pyproject.toml & poetry.lock first (for caching) ---
+# 4. Copy dependency files first (for Docker cache efficiency)
 COPY pyproject.toml poetry.lock* /app/
 
-# Install dependencies (no dev deps if production)
+# 5. Install project dependencies (no dev in production)
 RUN poetry install --no-interaction --no-ansi --without dev
 
-# --- Copy project source ---
+# 6. Copy project source
 COPY . /app
 
-# --- Run Nancy bot ---
+# 7. Run Nancy bot
 CMD ["poetry", "run", "nancy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,24 @@
-FROM python:3.12-alpine AS builder
+FROM python:3.12-slim
+
+# Install build deps
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       gcc libffi-dev libssl-dev build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Install build deps for wheels (aiohttp/yarl/etc.)
-RUN apk add --no-cache build-base libffi-dev openssl-dev
+# Copy dependency files
+COPY pyproject.toml poetry.lock* /app/
 
-# Copy project metadata
-ADD pyproject.toml poetry.lock /app/
+# Install poetry (just to export deps)
+RUN pip install "poetry==2.1.4"
 
-# Install Poetry and deps into in-project venv
-RUN pip install --no-cache-dir "poetry==2.1.4"
-RUN poetry config virtualenvs.in-project true
-RUN poetry install --no-ansi --no-interaction --only main
+# Export Poetry deps → requirements.txt → pip install
+RUN poetry export -f requirements.txt --without-hashes -o requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Final image
-FROM python:3.12-alpine
-WORKDIR /app
+# Copy app source
+COPY . /app
 
-# Runtime libs
-RUN apk add --no-cache libffi openssl
-
-# Bring venv and metadata from builder, then project sources
-COPY --from=builder /app /app
-ADD . /app
-
-# Create non-root user and set permissions
-RUN addgroup -g 1000 app \
- && adduser -h /app -u 1000 -G app -D app \
- && chown -R app:app /app
-USER app
-
-ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
-
-EXPOSE 8000
-
-# Run the aiohttp bot (no gunicorn; runs on port 8000)
-CMD ["/app/.venv/bin/python", "-m", "nancyai.bot"]
+CMD ["python", "-m", "nancyai.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock* /app/
 
 # ✅ Removed "--without dev" since you don’t have a dev group
-RUN poetry install --no-interaction --no-ansi
+RUN poetry install
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,40 @@
 # syntax=docker/dockerfile:1
 
 # Minimal, production-ready image for NancyAI bot
-FROM python:3.12-slim AS base
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-	PYTHONUNBUFFERED=1 \
-	PIP_NO_CACHE_DIR=1 \
-	PIP_DISABLE_PIP_VERSION_CHECK=1 \
-	# Default log path inside container (can be overridden)
-	BOT_LOG_FILE=/data/bot.log
-
-# System deps (certs) and clean up
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates \
-	&& rm -rf /var/lib/apt/lists/*
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    BOT_LOG_FILE=/data/bot.log
 
 WORKDIR /app
 
-# Install runtime dependencies directly (robust to build-backend differences)
-RUN pip install --upgrade pip \
-	&& pip install \
-		"python-dotenv>=1.0.0" \
-		"aiogram>=3.22.0" \
-		"groq>=0.8.0" \
-		"requests>=2.32.5,<3.0.0"
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
 
-# Copy source only
+RUN pip install --no-cache-dir "poetry==1.8.3"
+
+# Install deps first for better caching
+COPY pyproject.toml poetry.lock* ./
+RUN poetry install --no-interaction --no-ansi --only main
+
+# Copy source
 COPY src ./src
-
-# Ensure src is importable
 ENV PYTHONPATH=/app/src
 
-# Create a non-root user and writable data dir for logs
+# Non-root user and writable log dir
 RUN addgroup --system app \
-	&& adduser --system --ingroup app app \
-	&& mkdir -p /data \
-	&& chown -R app:app /data /app
-
+ && adduser --system --ingroup app app \
+ && mkdir -p /data \
+ && chown -R app:app /data /app
 USER app
 
-# Nancy runs an aiohttp app on 8000
 EXPOSE 8000
 
-# Required at runtime (set via env/compose):
-#   BOT_TOKEN, GROQ_API_KEY, OMDB_API_KEY, LOG_CHANNEL_ID (optional), WEBHOOK_HOST
-
-# Run from module to avoid packaging requirements
-CMD ["python", "-m", "nancyai.bot"]
+# Run via Poetry as requested
+CMD ["poetry", "run", "python", "-m", "nancyai.bot"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,20 @@
-# syntax=docker/dockerfile:1
+# --- Base image ---
+FROM python:3.11-slim
 
-FROM python:3.12-slim
+# --- Install dependencies ---
+RUN pip install --no-cache-dir poetry
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    POETRY_VIRTUALENVS_CREATE=false \
-    BOT_LOG_FILE=/data/bot.log
-
+# --- Set workdir ---
 WORKDIR /app
 
-# System deps (build tools for aiohttp/yarl, SSL/ffi headers, git for VCS deps)
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      build-essential \
-      python3-dev \
-      libffi-dev \
-      libssl-dev \
-      ca-certificates \
-      git \
- && rm -rf /var/lib/apt/lists/*
+# --- Copy pyproject.toml & poetry.lock first (for caching) ---
+COPY pyproject.toml poetry.lock* /app/
 
-# Poetry 2.1.4
-RUN pip install --no-cache-dir "poetry==2.1.4"
+# Install dependencies (no dev deps if production)
+RUN poetry install --no-interaction --no-ansi --without dev
 
-# Install dependencies first for better caching
-COPY pyproject.toml poetry.lock* ./
-RUN poetry install --no-interaction --no-ansi --no-root
+# --- Copy project source ---
+COPY . /app
 
-# Copy source and install the project (provides console scripts, etc.)
-COPY src ./src
-RUN poetry install --no-interaction --no-ansi
-
-# Non-root user and writable log dir
-RUN addgroup --system app \
- && adduser --system --ingroup app app \
- && mkdir -p /data \
- && chown -R app:app /data /app
-USER app
-
-EXPOSE 8000
-
-# Run with Poetry; use module entrypoint to avoid relying on a console script name
+# --- Run Nancy bot ---
 CMD ["poetry", "run", "nancy"]

--- a/src/nancyai/bot.py
+++ b/src/nancyai/bot.py
@@ -525,3 +525,6 @@ def main():
     setup_application(app, dp, bot=bot)
     logging.info("Bot started with webhook at %s", WEBHOOK_URL)
     web.run_app(app, host="0.0.0.0", port=8000)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request refactors the build and startup process for the bot application, focusing on simplifying the Dockerfile and improving dependency management. The changes streamline dependency installation, switch the startup command to use Python directly, and ensure the bot entry point is properly defined for execution.

**Dockerfile and build process improvements:**

* Switched from installing dependencies with Poetry at runtime to exporting dependencies to `requirements.txt` and installing them with pip, which is more standard and efficient for container builds.
* Added build dependencies (`gcc`, `libffi-dev`, `libssl-dev`, `build-essential`) to support Python package compilation.
* Changed the startup command from using Poetry to running the bot module directly with Python (`python -m nancyai.bot`).
* Copied the entire project source into the Docker image after dependency installation, improving layer caching and build performance.

**Bot entry point update:**

* Added a standard `if __name__ == "__main__": main()` block to `src/nancyai/bot.py` to ensure the bot can be started as a Python module.